### PR TITLE
Write all files into log dir

### DIFF
--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -7,10 +7,10 @@ import time
 from . import condor
 from . import slurm
 from .remote import INFILE_FMT, OUTFILE_FMT
-from .util import random_string
+from .util import random_string, local_filename
 import cloudpickle
 
-LOGFILE_FMT = 'cfut.log.%s.txt'
+LOGFILE_FMT = local_filename('cfut.log.%s.txt')
 
 class RemoteException(Exception):
     def __init__(self, error):

--- a/cfut/__init__.py
+++ b/cfut/__init__.py
@@ -65,6 +65,7 @@ class ClusterExecutor(futures.Executor):
     """An abstract base class for executors that run jobs on clusters.
     """
     def __init__(self, debug=False, keep_logs=False):
+        os.makedirs(local_filename(), exist_ok=True)
         self.debug = debug
 
         self.jobs = {}

--- a/cfut/condor.py
+++ b/cfut/condor.py
@@ -5,10 +5,11 @@ import re
 import os
 import threading
 import time
+from .util import local_filename
 
-LOG_FILE = "condorpy.log"
-OUTFILE_FMT = "condorpy.stdout.%s.log"
-ERRFILE_FMT = "condorpy.stderr.%s.log"
+LOG_FILE = local_filename("condorpy.log")
+OUTFILE_FMT = local_filename("condorpy.stdout.%s.log")
+ERRFILE_FMT = local_filename("condorpy.stderr.%s.log")
 
 def call(command, stdin=None):
     """Invokes a shell command as a subprocess, optionally with some
@@ -79,7 +80,7 @@ def submit_script(script, **kwargs):
     with the name of the temporary script file executed. (This should
     probably be removed once the job completes.)
     """
-    filename = 'condorpy.jobscript.%s'
+    filename = local_filename('condorpy.jobscript.%s')
     with open(filename, 'w') as f:
         f.write(script)
     os.chmod(filename, 0o755)

--- a/cfut/remote.py
+++ b/cfut/remote.py
@@ -3,9 +3,10 @@ import cloudpickle
 import sys
 import os
 import traceback
+from .util import local_filename
 
-INFILE_FMT = 'cfut.in.%s.pickle'
-OUTFILE_FMT = 'cfut.out.%s.pickle'
+INFILE_FMT = local_filename('cfut.in.%s.pickle')
+OUTFILE_FMT = local_filename('cfut.out.%s.pickle')
 
 def format_remote_exc():
     typ, value, tb = sys.exc_info()

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -4,16 +4,16 @@ import re
 import os
 import threading
 import time
-from .util import chcall, random_string
+from .util import chcall, random_string, local_filename
 
-LOG_FILE = "slurmpy.log"
-OUTFILE_FMT = "slurmpy.stdout.{}.log"
+LOG_FILE = local_filename("slurmpy.log")
+OUTFILE_FMT = local_filename("slurmpy.stdout.{}.log")
 
 def submit_text(job):
     """Submits a Slurm job represented as a job file string. Returns
     the job ID.
     """
-    filename = '_temp_{}.sh'.format(random_string())
+    filename = local_filename('_temp_{}.sh'.format(random_string()))
     with open(filename, 'w') as f:
         f.write(job)
     jobid, _ = chcall('sbatch --parsable {}'.format(filename))

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -1,6 +1,10 @@
 import subprocess
 import random
 import string
+import os
+
+def local_filename(filename):
+    return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
 
 def random_string(length=32, chars=(string.ascii_letters + string.digits)):
     return ''.join(random.choice(chars) for i in range(length))

--- a/cfut/util.py
+++ b/cfut/util.py
@@ -3,7 +3,7 @@ import random
 import string
 import os
 
-def local_filename(filename):
+def local_filename(filename=""):
     return os.path.join(os.getenv("CFUT_DIR", ".cfut"), filename)
 
 def random_string(length=32, chars=(string.ascii_letters + string.digits)):


### PR DESCRIPTION
Write all temporary and log files into a configurable directory instead of the current working directory. By default the folder `.cfut` is used, but configurable by `CFUT_DIR` env variable.